### PR TITLE
Added swift_version parameter

### DIFF
--- a/SimpleImageViewer.podspec
+++ b/SimpleImageViewer.podspec
@@ -4,6 +4,7 @@ Pod::Spec.new do |s|
   s.name = "SimpleImageViewer"
   s.summary = "A snappy image viewer with zoom and interactive dismissal transition."
   s.requires_arc = true
+  s.swift_version = '4.2'
   s.version = "1.1.1"
   s.license = { :type => "MIT", :file => "LICENSE" }
   s.author = { "Lucas" => "lucas@afrogleap.com" }


### PR DESCRIPTION
Fixes # .
Newer cocoapods releases recommend specifying a swift_version parameter in podspec file.
Changes proposed in this pull request: 
- added said parameter
-
-
